### PR TITLE
DownloadPage - Fix version command

### DIFF
--- a/main/src/main/groovy/io/micronaut/main/pages/DownloadPage.groovy
+++ b/main/src/main/groovy/io/micronaut/main/pages/DownloadPage.groovy
@@ -96,7 +96,7 @@ class DownloadPage extends Page {
                         }
                         p 'If prompted, make this your default version. After installation is complete it can be tested with:'
                         div(class: 'code') {
-                            p '$ mn -version'
+                            p '$ mn --version'
                         }
                         p 'That\'s all there is to it!'
                     }


### PR DESCRIPTION
The command `mn -version`produces the default output:

```
Usage: 
	 create-app [NAME] 
	 create-cli-app [NAME] \n\t create-federation [NAME] --services SERVICE_NAME[,SERVICE_NAME]... 
	 create-function [NAME]  

| Available Profiles
--------------------
  base          The base profile
  cli           The cli profile
  federation    The federation profile
  function      The function profile
  function-aws  The function profile for AWS Lambda
  kafka         The Kafka messaging profile
  profile       A profile for creating new Micronaut profiles
  service       The service profile

Type 'mn help' or 'mn -h' for more information.
```

while the command `mn --version` produces the version output:

```
| Micronaut Version: 1.0.0.M4
| JVM Version: 1.8.0_144
```