### PR TITLE
Use correct option to get version.

### DIFF
--- a/main/src/main/groovy/io/micronaut/main/pages/DownloadPage.groovy
+++ b/main/src/main/groovy/io/micronaut/main/pages/DownloadPage.groovy
@@ -96,7 +96,7 @@ class DownloadPage extends Page {
                         }
                         p 'If prompted, make this your default version. After installation is complete it can be tested with:'
                         div(class: 'code') {
-                            p '$ mn -version'
+                            p '$ mn --version'
                         }
                         p 'That\'s all there is to it!'
                     }


### PR DESCRIPTION
I just tested it in Micronaut 1.0.0.RC1: to get version the option to use should be --version or -V.