### PR TITLE
Added Open Graph tags

### DIFF
--- a/main/src/main/js/launch/public/index.html
+++ b/main/src/main/js/launch/public/index.html
@@ -9,6 +9,17 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.css">
 
     <link rel="icon" href="https://micronaut.io/images/favicon.ico">
+    
+    <meta name='twitter:card' content='summary_large_image' />
+    <meta name='twitter:site' content='@micronautfw' />
+    <meta name='twitter:creator' content='@micronautfw' />
+    <meta property='og:image' content='https://micronaut.io/images/Micronaut_OG_Logo.png' />
+    <meta property='og:image:width' content='600' />
+    <meta property='og:image:height' content='300' />
+    <meta property='og:url' content='https://micronaut.io/launch' />
+    <meta property='og:title' content='Micronaut Launch' />
+    <meta property='og:description' content='A modern, JVM-based, full-stack framework for building modular, easily testable microservice and serverless applications.' />
+    <meta property='og:type' content='website' />
 
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Modified from the OG tags already in use on the Micronaut homepage.

Note: The actual Micronaut Launch logo is transparent and won't work well as a preview image, so I'm using this black on white Micronaut logo: https://micronaut.io/images/Micronaut_OG_Logo.png

If someone can point me to a similar Launch logo with a solid background, I will update the image URL.