### PR TITLE
Add Keyboard scrolling to Feature Selector

### DIFF
--- a/main/src/main/js/launch/src/components/FeatureSelector/FeatureSelector.js
+++ b/main/src/main/js/launch/src/components/FeatureSelector/FeatureSelector.js
@@ -18,6 +18,7 @@ import "./feature-selector.css";
 
 const keyboardEventHandler = new ModalKeyboardHandler({
     sectionKey: "modal-group",
+    headerHeight: 24,
 });
 
 const featureSorter = (a, b) => {

--- a/main/src/main/js/launch/src/components/FeatureSelector/FeatureSelector.js
+++ b/main/src/main/js/launch/src/components/FeatureSelector/FeatureSelector.js
@@ -10,15 +10,20 @@ import Row from "react-materialize/lib/Row";
 import FeatureAvailable from "./FeatureAvailable";
 import FeatureSelected from "./FeatureSelected";
 import TextInput from "../TextInput";
-
-import messages from "../../constants/messages.json";
 import TooltipButton from "../TooltipButton";
+import messages from "../../constants/messages.json";
+import { ModalKeyboardHandler } from "../../helpers/ModalKeyboardHandler";
 
 import "./feature-selector.css";
+
+const keyboardEventHandler = new ModalKeyboardHandler({
+    sectionKey: "modal-group",
+});
 
 const featureSorter = (a, b) => {
     return a.category < b.category ? -1 : a.name < b.name ? -1 : 1;
 };
+
 const featureCategoryReducer = (map, result) => {
     if (!map[result.category]) {
         map[result.category] = [result];
@@ -30,7 +35,7 @@ const featureCategoryReducer = (map, result) => {
 
 const FeatureAvailableGroup = ({ category, entities, toggleFeatures }) => {
     return (
-        <Row>
+        <Row className={`modal-group category ${category}`}>
             <Col s={12}>
                 <h6>{category}</h6>
             </Col>
@@ -145,6 +150,8 @@ export const FeatureSelectorModal = ({
                     </Button>,
                 ]}
                 options={{
+                    onOpenEnd: keyboardEventHandler.onOpenEnd,
+                    onCloseEnd: keyboardEventHandler.onCloseEnd,
                     onCloseStart: onModalClose,
                     startingTop: "5%",
                     endingTop: "5%",

--- a/main/src/main/js/launch/src/components/FeatureSelector/feature-selector.css
+++ b/main/src/main/js/launch/src/components/FeatureSelector/feature-selector.css
@@ -1,4 +1,8 @@
 /* Modal */
+.modal.mn-feature-modal {
+    overflow-y: hidden;
+}
+
 .mn-feature-modal .modal-content h4 {
     position: fixed;
     top: 0;
@@ -11,7 +15,13 @@
 }
 
 .mn-feature-modal .modal-content {
-    padding-top: 7em;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+    height: calc(100% - 130px);
+    margin-top: 74px;
+    margin-bottom: 56px;
+    padding-bottom: 56px;
 }
 
 .mn-feature-modal .modal-content h4 .helper-text {
@@ -78,7 +88,12 @@ body.light .mn-feature-container .card .card-title {
         max-height: 100% !important;
         width: 100% !important;
         max-width: 100% !important;
-        top: 0% !important;
+        top: 0 !important;
+        bottom: 0 !important;
         font-size: 14px;
+    }
+
+    .mn-feature-modal .modal-content {
+        padding-bottom: 56px;
     }
 }

--- a/main/src/main/js/launch/src/helpers/ModalKeyboardHandler.js
+++ b/main/src/main/js/launch/src/helpers/ModalKeyboardHandler.js
@@ -1,0 +1,111 @@
+const DEFAULT_HEADER_HEIGHT = 100;
+
+const KEY_PAGE_UP = 33;
+const KEY_PAGE_DOWN = 34;
+const KEY_LEFT = 37;
+const KEY_UP = 38;
+const KEY_RIGHT = 39;
+const KEY_DOWN = 40;
+
+const FN_NEXT_PAGE = (node, { headerHeight = DEFAULT_HEADER_HEIGHT }) => {
+    node.scrollTop += node.clientHeight - headerHeight;
+};
+
+const FN_PREV_PAGE = (node, { headerHeight = DEFAULT_HEADER_HEIGHT }) => {
+    node.scrollTop -= node.clientHeight - headerHeight;
+};
+
+const FN_JUMP_TO_NEXT_GROUP = (
+    node,
+    { sectionKey = "modal-group", headerHeight = DEFAULT_HEADER_HEIGHT }
+) => {
+    const groups = [...node.getElementsByClassName(sectionKey)];
+    if (!groups.length) {
+        return (node.scrollTop += headerHeight);
+    }
+    const next = groups.filter(
+        (a) => a.offsetTop > node.scrollTop + headerHeight
+    );
+    if (!next.length) return;
+    const group = next[0];
+    const scrollTop = group.offsetTop;
+    node.scrollTop = scrollTop - headerHeight;
+};
+
+const FN_JUMP_TO_PREV_GROUP = (
+    node,
+    { sectionKey = "modal-group", headerHeight = DEFAULT_HEADER_HEIGHT }
+) => {
+    const groups = [...node.getElementsByClassName(sectionKey)];
+    if (!groups.length) {
+        node.scrollTop -= headerHeight;
+    }
+    const next = groups.filter(
+        (a) => a.offsetTop < node.scrollTop + headerHeight
+    );
+    if (!next.length) {
+        return;
+    }
+    const group = next[next.length - 1];
+    const scrollTop = group.offsetTop;
+    node.scrollTop = scrollTop - headerHeight;
+};
+
+export class ModalKeyboardHandler {
+    constructor(
+        config = {
+            sectionKey: "modal-group",
+            headerHeight: DEFAULT_HEADER_HEIGHT,
+            hasHeader: true,
+        }
+    ) {
+        if (!config instanceof Object) {
+            throw Error(
+                "ModalKeyboardHandler must be created with a config object"
+            );
+        }
+        this.config = config;
+        if (this.config.hasHeader === false) {
+            this.confin.headerHeight = 0;
+        }
+    }
+
+    getAction(keyCode) {
+        switch (keyCode) {
+            case KEY_UP:
+                return -50;
+            case KEY_DOWN:
+                return 50;
+            case KEY_RIGHT:
+                return FN_JUMP_TO_NEXT_GROUP;
+            case KEY_LEFT:
+                return FN_JUMP_TO_PREV_GROUP;
+            case KEY_PAGE_UP:
+                return FN_PREV_PAGE;
+            case KEY_PAGE_DOWN:
+                return FN_NEXT_PAGE;
+            default:
+                return false;
+        }
+    }
+
+    handler = (e) => {
+        const { target, keyCode } = e;
+        console.log({ keyCode });
+        const node = target.getElementsByClassName("modal-content")[0];
+        let action = this.getAction(keyCode);
+        if (!action) {
+            return;
+        }
+        if (action instanceof Function) {
+            action(node, this.config);
+        } else {
+            node.scrollTop += action;
+        }
+    };
+
+    onOpenEnd = (node) => node.addEventListener("keydown", this.handler);
+    onCloseEnd = (node) => {
+        node.removeEventListener("keydown", this.handler);
+    };
+}


### PR DESCRIPTION
Addresses https://github.com/micronaut-projects/micronaut-starter/issues/204

I'm up for suggestions on the specifics of key handling. 

Current Keymapping
Up - Moves 50px up
Down - Moves 50px down
Left - Jumps to previous Category
Right - Jumps to next Category
Page Down - Jumps to next visible area (+ modal height)
Page Up - Jumps to prev visible area (+ modal height)
