### PR TITLE
add links to faq and upcoming events from learn

### DIFF
--- a/pages/learn.html
+++ b/pages/learn.html
@@ -33,5 +33,26 @@ title: Learn Micronaut
                 </article>
             </div>
         </div>
+        <div class="threecolumns">
+            <div class='column'>
+                <article class='blogcard' style="background-image: url([%url]/images/faq.png)">
+                    <a href='[%url]/faq.html'>
+                        <h3>&nbsp;</h3>
+                        <h2>FAQ</h2>
+                    </a>
+                </article>
+            </div>
+            <div class='column'>
+                <article class='blogcard' style='background-image: url([%url]/images/events.png)'>
+                    <a href='[%url]/events.html'>
+                        <h3>&nbsp;</h3>
+                        <h2>Upcoming Events
+                        </h2>
+                    </a>
+                </article>
+            </div>
+            <div class='column'>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
This is how it looks like: 

<img width="1249" alt="Screenshot 2020-08-25 at 16 16 53" src="https://user-images.githubusercontent.com/864788/91185733-77848580-e6ee-11ea-942d-47b30ae37ef8.png">


see: https://github.com/micronaut-projects/static-website-private/issues/37

No third box because Microcast does not exist yet. 