### PR TITLE
Updates install links to point to documentation in starter (#169)

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/download/DownloadPage.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/download/DownloadPage.groovy
@@ -29,11 +29,9 @@ class DownloadPage {
         new GuideGroup(title: "Install",
                 image: "${getImageAssetPreffix(url)}download.svg",
                 items: [
-                        new GuideGroupItem(href: "https://docs.micronaut.io/latest/guide/index.html#installSdkman", title: 'Install with SDKman'),
-                        new GuideGroupItem(href: "https://docs.micronaut.io/latest/guide/index.html#installHomebrew", title: 'Install with Homebrew'),
-                        new GuideGroupItem(href: "https://docs.micronaut.io/latest/guide/index.html#installMacPorts", title: 'Install with MacPorts'),
-                        new GuideGroupItem(href: "https://docs.micronaut.io/latest/guide/index.html#installWindows", title: 'Install through Binary on Windows'),
-                        new GuideGroupItem(href: "https://docs.micronaut.io/latest/guide/index.html#buildSource", title: 'Building from Source'),
+                        new GuideGroupItem(href: "https://micronaut-projects.github.io/micronaut-starter/latest/guide/index.html#installSdkman", title: 'Install with SDKman'),
+                        new GuideGroupItem(href: "https://micronaut-projects.github.io/micronaut-starter/latest/guide/index.html#installHomebrew", title: 'Install with Homebrew'),
+                        new GuideGroupItem(href: "https://micronaut-projects.github.io/micronaut-starter/latest/guide/index.html#installChocolatey", title: 'Install with Chocolatey'),
                 ])
     }
 


### PR DESCRIPTION
I know there is another PR is draft state for this (#163), but it still has the build from source link in it and some conversation around the sections existence in the documentation.  I put this together before I noticed that PR and I want to merge it because it will get the site back to a correct state regarding what documentation is available.  

I also created some other issues for the gaps I noticed:

https://github.com/micronaut-projects/micronaut-starter/issues/499
https://github.com/micronaut-projects/micronaut-starter/issues/500
https://github.com/micronaut-projects/micronaut-starter/issues/501