### PR TITLE
Change binary download link

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/download/DownloadPage.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/download/DownloadPage.groovy
@@ -21,7 +21,7 @@ class DownloadPage {
                 image: "${getImageAssetPreffix(url)}download.svg",
                 items: [
                         new GuideGroupItem(href: "https://github.com/micronaut-projects/micronaut-core/releases/tag/v${latestVersion}", title: 'Release Notes'),
-                        new GuideGroupItem(href: "https://github.com/micronaut-projects/micronaut-starter/releases/download/v${latestVersion}/micronaut-cli-${latestVersion}.zip", title: 'Binary'),
+                        new GuideGroupItem(href: "https://github.com/micronaut-projects/micronaut-starter/releases/tag/v${latestVersion}", title: 'Binaries'),
                 ])
     }
 


### PR DESCRIPTION
Change binary download link to point to micronaut-starter releases page instead of the micronaut-core source zip.

It's possible the original documentation meant to download the source, but newer starter documentation implies that the download will include the mn executable. If team still wants to provide a link to download the source package as a zip here, perhaps it should be two different links. 

Resolves #219